### PR TITLE
[RAFD-1561] Fix for change in hdfs-site.xml in Hadoop 3.1 for JCEKS path

### DIFF
--- a/wrangler-service/src/main/java/co/cask/wrangler/service/adls/ParseConf.java
+++ b/wrangler-service/src/main/java/co/cask/wrangler/service/adls/ParseConf.java
@@ -27,7 +27,7 @@ public class ParseConf {
 
     public static String getClusterName() throws IOException {
         Configuration conf = new Configuration();
-        String clusterName = conf.get("dfs.internal.nameservices");
+        String clusterName = conf.get("dfs.nameservices");
         if(clusterName == null || clusterName.isEmpty()){
             throw new IOException("issue with hdfs-site.xml");
         }


### PR DESCRIPTION
"dfs.nameservices" is used to fetch cluster name instead of dfs.internal.nameservices