### PR TITLE
RAFD-3296: decodeArray() for parsing array type field is corrected to…

### DIFF
--- a/wrangler-core/src/main/java/co/cask/wrangler/utils/RecordConvertor.java
+++ b/wrangler-core/src/main/java/co/cask/wrangler/utils/RecordConvertor.java
@@ -403,7 +403,7 @@ public final class RecordConvertor implements Serializable {
 
   private List<Object> decodeArray(String name, List list, Schema schema) throws RecordConvertorException {
     List<Object> array = Lists.newArrayListWithCapacity(list.size());
-    for (Object object : array) {
+    for (Object object : list) {
       array.add(decode(name, object, schema));
     }
     return array;


### PR DESCRIPTION
… iterate through passed list object, rather than local empty object